### PR TITLE
rbenv users may be in the dark

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ INSTALL
 -------
  * Requires: gem install hpricot
  * Install with pathogen: clone/submodule into vim/bundle
+ * **rbenv** users will need to install hpricot using system ruby `RBENV_VERSION=system sudo gem install hpricot`
 
 USAGE
 -----


### PR DESCRIPTION
I've added documentation to your README so that rbenv users will not become confused when they see hpricot requirement demands even though then ran `gem install hpricot`

The gem will need to be installed with system ruby.
