### PR TITLE
Modified quitting rspec window behavior

### DIFF
--- a/plugin/vim-rspec.vim
+++ b/plugin/vim-rspec.vim
@@ -164,7 +164,7 @@ function! s:RunSpecMain(type)
   silent exec "nnoremap <buffer> <cr> :call <SID>TryToOpen()<cr>"
   silent exec 'nnoremap <silent> <buffer> n /\/.*spec.*\:<cr>:call <SID>TryToOpen()<cr>'
   silent exec 'nnoremap <silent> <buffer> N ?/\/.*spec.*\:<cr>:call <SID>TryToOpen()<cr>'
-  silent exec "nnoremap <buffer> q :q<CR>"
+  silent exec "nnoremap <buffer> q :q<CR>:wincmd p<CR>"
   setl nolist
   setl foldmethod=expr
   setl foldexpr=getline(v:lnum)=~'^\+'


### PR DESCRIPTION
Current mapping took me to the first wndow on the vim tab, when you have multiple windows this is annoying, updated the mapping such that it will move the mouse back to the previous window after quitting rspec output window.
