### PR TITLE
Updated install instructions for rbenv users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ INSTALL
 -------
  * Requires: gem install hpricot
  * Install with pathogen: clone/submodule into vim/bundle
- * **rbenv** users will need to install hpricot using system ruby `RBENV_VERSION=system sudo gem install hpricot`
+ * **rbenv** users will need to install hpricot using system ruby `sudo RBENV_VERSION=system gem install hpricot`
 
 USAGE
 -----


### PR DESCRIPTION
Previous command install hpricot gem into rbenv's gem directory instead of a
global. It was caused by improper placement of sudo - RBENV_VERSION was set only for
local user so applying sudo ignored it.

To fix this problem sudo have to goes before set of environment variable.
