### PR TITLE
allow user to set split size

### DIFF
--- a/plugin/vim-rspec.vim
+++ b/plugin/vim-rspec.vim
@@ -53,9 +53,11 @@ function! s:createOutputWin()
   if !exists("g:RspecSplitHorizontal")
     let g:RspecSplitHorizontal=1
   endif
-
+  if !exists("g:RspecSplitSize")
+    let g:RspecSplitSize=15
+  endif
   let splitLocation = "botright "
-  let splitSize = 15
+  let splitSize = g:RspecSplitSize
 
   if bufexists('RSpecOutput')
     silent! bw! RSpecOutput


### PR DESCRIPTION
I added the ability to configure the split size for the results window through
an option in .vimrc.

The option `g:RspecSplitSize` defaults to 15, which is the split size used
in the code this commit replaces. Users who don't set `g:RspecSplitSize` in
their vimrc won't see any change in behavior, while users who prefer a
larger results pane can set the split size higher.
