### PR TITLE
Fix invalid -l option

### DIFF
--- a/plugin/vim-rspec.vim
+++ b/plugin/vim-rspec.vim
@@ -114,7 +114,7 @@ function! s:RunSpecMain(type)
       call s:notice_msg("Running Line " . l:current_line . " on " . s:SpecFile . " ")
       let l:spec_bin = s:fetch("RspecBin",l:default_cmd)
       let l:spec_opts = s:fetch("RspecOpts", "")
-      let l:spec = l:spec_bin . " " . l:spec_opts . " -l " . l:current_line . " -f h " . l:bufn
+      let l:spec = l:spec_bin . " " . l:spec_opts . " -f h " . l:bufn . ":" . l:current_line
     else
       call s:error_msg("Seems ".l:bufn." is not a *_spec.rb file")
       return


### PR DESCRIPTION
Line number option `-l` is no longer available in rspec 3.x.
This solution is working with rspec 2.x as well.
